### PR TITLE
Use a more-efficient queue for notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Experiments in making music with Elixir, for a forthcoming talk at the [Indy Eli
 ```
 $ git clone git@github.com:stevegrossi/sweet_beats.git
 $ brew install sox
+$ mix deps.get
 $ mix run --no-halt
 ```
 

--- a/lib/sweet_beats/rhythm.ex
+++ b/lib/sweet_beats/rhythm.ex
@@ -5,7 +5,8 @@ defmodule SweetBeats.Rhythm do
   @microseconds_between_notes 250_000
 
   def start_link(start_time, sample_file, notes) do
-    GenServer.start_link(__MODULE__, {start_time, sample_file, notes})
+    notes_queue = EQueue.from_list(notes)
+    GenServer.start_link(__MODULE__, {start_time, sample_file, notes_queue})
   end
 
   def init(state) do
@@ -13,9 +14,11 @@ defmodule SweetBeats.Rhythm do
     {:ok, state}
   end
 
-  def handle_info(:play, {start_time, sample_file, [head | tail]}) do
-    play_sample(sample_file, head)
-    shifted_notes = tail ++ [head]
+  def handle_info(:play, {start_time, sample_file, notes_queue}) do
+    {:value, current_note, updated_queue} = EQueue.pop(notes_queue)
+    play_sample(sample_file, current_note)
+    shifted_notes = EQueue.push(updated_queue, current_note)
+
     delta = :os.system_time(:microsecond) - start_time
     time_to_next_note = @microseconds_between_notes - delta
     Process.send_after(self(), :play, round(time_to_next_note / 1000))

--- a/mix.exs
+++ b/mix.exs
@@ -28,6 +28,8 @@ defmodule SweetBeats.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    []
+    [
+      {:e_queue, "~> 1.0.0"}
+    ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,1 @@
+%{"e_queue": {:hex, :e_queue, "1.0.1", "cee5d830e47938250c56a34de2b34028adbae867e6bccceb2e0edf36e2543680", [:mix], []}}


### PR DESCRIPTION
…rather than adding elements to the end of lists, because that’s really slow.

Thanks Ben! https://hex.pm/packages/e_queue